### PR TITLE
hardcoded mypy version, as > v0.812 causes issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3
-RUN pip3 install flake8 mypy isort
+RUN pip3 install flake8 isort
+# hardcode b/c mypy > v0.812 has issue with --ignore-missing-imports. will remove when fixed
+RUN pip3 install mypy==v0.812
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
`--ignore-missing-imports` flag not ignoring library stubs